### PR TITLE
updated for compatibility with LLVM 10

### DIFF
--- a/src/FixItExporter.cpp
+++ b/src/FixItExporter.cpp
@@ -68,7 +68,7 @@ void FixItExporter::BeginSourceFile(const LangOptions &LangOpts, const Preproces
 
     const auto id = SourceMgr.getMainFileID();
     const auto entry = SourceMgr.getFileEntryForID(id);
-    getTuDiag().MainSourceFile = entry->getName();
+    getTuDiag().MainSourceFile = static_cast<std::string>(entry->getName());
 }
 
 bool FixItExporter::IncludeInDiagnosticCounts() const
@@ -89,7 +89,8 @@ tooling::Diagnostic FixItExporter::ConvertDiagnostic(const Diagnostic &Info)
     // TODO: This returns an empty string: DiagEngine->getDiagnosticIDs()->getWarningOptionForDiag(Info.getID());
     // HACK: capture it at the end of the message: Message text [check-name]
 
-    std::string checkName = DiagEngine.getDiagnosticIDs()->getWarningOptionForDiag(Info.getID());
+    std::string checkName =
+        static_cast<std::string>(DiagEngine.getDiagnosticIDs()->getWarningOptionForDiag(Info.getID()));
     std::string messageText;
 
     if (checkName.empty()) {

--- a/src/MiniAstDumper.cpp
+++ b/src/MiniAstDumper.cpp
@@ -24,6 +24,7 @@
 
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendPluginRegistry.h>
+#include <clang/Basic/FileManager.h>
 
 using namespace clang;
 using namespace std;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -878,7 +878,7 @@ string Utils::filenameForLoc(SourceLocation loc, const clang::SourceManager &sm)
     if (loc.isMacroID())
         loc = sm.getExpansionLoc(loc);
 
-    const string filename = sm.getFilename(loc);
+    const string filename = static_cast<std::string>(sm.getFilename(loc));
     auto splitted = clazy::splitString(filename, '/');
     if (splitted.empty())
         return {};

--- a/src/checkbase.cpp
+++ b/src/checkbase.cpp
@@ -188,7 +188,7 @@ bool CheckBase::shouldIgnoreFile(SourceLocation loc) const
     if (!loc.isValid())
         return true;
 
-    string filename = sm().getFilename(loc);
+    string filename = static_cast<std::string>(sm().getFilename(loc));
 
     return clazy::any_of(m_filesToIgnore, [filename](const std::string &ignored) {
         return clazy::contains(filename, ignored);

--- a/src/checks/detachingbase.cpp
+++ b/src/checks/detachingbase.cpp
@@ -57,7 +57,7 @@ bool DetachingBase::isDetachingMethod(CXXMethodDecl *method, DetachingMethodType
 
     const std::unordered_map<string, std::vector<StringRef>> &methodsByType = detachingMethodType == DetachingMethod ? clazy::detachingMethods()
                                                                                                                      : clazy::detachingMethodsWithConstCounterParts();
-    auto it = methodsByType.find(className);
+    auto it = methodsByType.find(static_cast<std::string>(className));
     if (it != methodsByType.cend()) {
         const auto &methods = it->second;
         if (clazy::contains(methods, clazy::name(method)))

--- a/src/checks/level0/qenums.cpp
+++ b/src/checks/level0/qenums.cpp
@@ -59,7 +59,7 @@ void QEnums::VisitMacroExpands(const Token &MacroNameTok, const SourceRange &ran
         // We simply check if :: is present because it's very cumbersome to to check for different classes when dealing with the pre-processor
 
         CharSourceRange crange = Lexer::getAsCharRange(range, sm(), lo());
-        string text = Lexer::getSourceText(crange, sm(), lo());
+        string text = static_cast<std::string>(Lexer::getSourceText(crange, sm(), lo()));
         if (clazy::contains(text, "::"))
             return;
     }

--- a/src/checks/level0/qt-macros.cpp
+++ b/src/checks/level0/qt-macros.cpp
@@ -44,7 +44,7 @@ void QtMacros::VisitMacroDefined(const Token &MacroNameTok)
         return;
 
     IdentifierInfo *ii = MacroNameTok.getIdentifierInfo();
-    if (ii && clazy::startsWith(ii->getName(), "Q_OS_"))
+    if (ii && clazy::startsWith(static_cast<std::string>(ii->getName()), "Q_OS_"))
         m_OSMacroExists = true;
 }
 
@@ -58,7 +58,7 @@ void QtMacros::checkIfDef(const Token &macroNameTok, SourceLocation Loc)
     if (preProcessorVisitor && preProcessorVisitor->qtVersion() < 51204 && ii->getName() == "Q_OS_WINDOWS") {
         // Q_OS_WINDOWS was introduced in 5.12.4
         emitWarning(Loc, "Q_OS_WINDOWS was only introduced in Qt 5.12.4, use Q_OS_WIN instead");
-    } else if (!m_OSMacroExists && clazy::startsWith(ii->getName(), "Q_OS_")) {
+    } else if (!m_OSMacroExists && clazy::startsWith(static_cast<std::string>(ii->getName()), "Q_OS_")) {
         emitWarning(Loc, "Include qglobal.h before testing Q_OS_ macros");
     }
 }

--- a/src/checks/level0/unused-non-trivial-variable.cpp
+++ b/src/checks/level0/unused-non-trivial-variable.cpp
@@ -91,7 +91,7 @@ bool UnusedNonTrivialVariable::isUninterestingType(const CXXRecordDecl *record) 
     static const vector<StringRef> blacklistedTemplates = { "QScopedPointer", "QSetValueOnDestroy", "QScopedValueRollback" };
     StringRef className = clazy::name(record);
     for (StringRef templateName : blacklistedTemplates) {
-        if (clazy::startsWith(className, templateName))
+        if (clazy::startsWith(static_cast<std::string>(className), static_cast<std::string>(templateName)))
             return true;
     }
 

--- a/src/checks/level1/detaching-temporary.cpp
+++ b/src/checks/level1/detaching-temporary.cpp
@@ -140,7 +140,7 @@ void DetachingTemporary::VisitStmt(clang::Stmt *stm)
     StringRef className = clazy::name(classDecl);
 
     const std::unordered_map<string, std::vector<StringRef>> &methodsByType = clazy::detachingMethods();
-    auto it = methodsByType.find(className);
+    auto it = methodsByType.find(static_cast<std::string>(className));
     auto it2 = m_writeMethodsByType.find(className);
 
     std::vector<StringRef> allowedFunctions;

--- a/src/checks/level1/non-pod-global-static.cpp
+++ b/src/checks/level1/non-pod-global-static.cpp
@@ -74,7 +74,7 @@ void NonPodGlobalStatic::VisitStmt(clang::Stmt *stm)
     const SourceLocation declStart = clazy::getLocStart(varDecl);
 
     if (declStart.isMacroID()) {
-        auto macroName = Lexer::getImmediateMacroName(declStart, sm(), lo());
+        auto macroName = static_cast<std::string>(Lexer::getImmediateMacroName(declStart, sm(), lo()));
         if (clazy::startsWithAny(macroName, { "Q_IMPORT_PLUGIN", "Q_CONSTRUCTOR_FUNCTION", "Q_DESTRUCTOR_FUNCTION"})) // Don't warn on these
             return;
     }

--- a/src/checks/level1/qproperty-without-notify.cpp
+++ b/src/checks/level1/qproperty-without-notify.cpp
@@ -69,7 +69,7 @@ void QPropertyWithoutNotify::VisitMacroExpands(const clang::Token &MacroNameTok,
         return;
     CharSourceRange crange = Lexer::getAsCharRange(range, sm(), lo());
 
-    string text = Lexer::getSourceText(crange, sm(), lo());
+    string text = static_cast<std::string>(Lexer::getSourceText(crange, sm(), lo()));
     if (text.back() == ')')
         text.pop_back();
 

--- a/src/checks/level2/missing-typeinfo.cpp
+++ b/src/checks/level2/missing-typeinfo.cpp
@@ -74,7 +74,7 @@ void MissingTypeInfo::VisitDecl(clang::Decl *decl)
         if (sm().isInSystemHeader(clazy::getLocStart(record)))
             return;
 
-        std::string typeName = clazy::name(record);
+        std::string typeName = static_cast<std::string>(clazy::name(record));
         if (typeName == "QPair") // QPair doesn't use Q_DECLARE_TYPEINFO, but rather a explicit QTypeInfo.
             return;
 

--- a/src/checks/level2/old-style-connect.cpp
+++ b/src/checks/level2/old-style-connect.cpp
@@ -274,7 +274,7 @@ void OldStyleConnect::VisitMacroExpands(const Token &macroNameTok, const SourceR
         return;
 
     auto charRange = Lexer::getAsCharRange(range, sm(), lo());
-    const string text = Lexer::getSourceText(charRange, sm(), lo());
+    const string text = static_cast<std::string>(Lexer::getSourceText(charRange, sm(), lo()));
 
     static regex rx(R"(Q_PRIVATE_SLOT\s*\((.*)\s*,\s*.*\s+(.*)\(.*)");
     smatch match;
@@ -293,7 +293,7 @@ string OldStyleConnect::signalOrSlotNameFromMacro(SourceLocation macroLoc)
     CharSourceRange expansionRange = clazy::getImmediateExpansionRange(macroLoc, sm());
     SourceRange range = SourceRange(expansionRange.getBegin(), expansionRange.getEnd());
     auto charRange = Lexer::getAsCharRange(range, sm(), lo());
-    const string text = Lexer::getSourceText(charRange, sm(), lo());
+    const string text = static_cast<std::string>(Lexer::getSourceText(charRange, sm(), lo()));
 
     static regex rx(R"(\s*(SIGNAL|SLOT)\s*\(\s*(.+)\s*\(.*)");
 
@@ -315,7 +315,7 @@ bool OldStyleConnect::isSignalOrSlot(SourceLocation loc, string &macroName) cons
     if (!loc.isMacroID() || loc.isInvalid())
         return false;
 
-    macroName = Lexer::getImmediateMacroName(loc, sm(), lo());
+    macroName = static_cast<std::string>(Lexer::getImmediateMacroName(loc, sm(), lo()));
     return macroName == "SIGNAL" || macroName == "SLOT";
 }
 

--- a/src/checks/level2/rule-of-three.cpp
+++ b/src/checks/level2/rule-of-three.cpp
@@ -140,7 +140,7 @@ void RuleOfThree::VisitDecl(clang::Decl *decl)
 
     const string className = record->getNameAsString();
     const string classQualifiedName = record->getQualifiedNameAsString();
-    const string filename = sm().getFilename(recordStart);
+    const string filename = static_cast<std::string>(sm().getFilename(recordStart));
     if (clazy::endsWith(className, "Private") && clazy::endsWithAny(filename, { ".cpp", ".cxx", "_p.h" }))
         return; // Lots of RAII classes fall into this category. And even Private (d-pointer) classes, warning in that case would just be noise
 

--- a/src/checks/manuallevel/ifndef-define-typo.cpp
+++ b/src/checks/manuallevel/ifndef-define-typo.cpp
@@ -44,7 +44,7 @@ void IfndefDefineTypo::VisitMacroDefined(const Token &macroNameTok)
 {
     if (!m_lastIfndef.empty()) {
         if (IdentifierInfo *ii = macroNameTok.getIdentifierInfo()) {
-            maybeWarn(ii->getName(), macroNameTok.getLocation());
+            maybeWarn(static_cast<std::string>(ii->getName()), macroNameTok.getLocation());
         }
     }
 }
@@ -53,7 +53,7 @@ void IfndefDefineTypo::VisitDefined(const Token &macroNameTok, const SourceRange
 {
     if (!m_lastIfndef.empty()) {
         if (IdentifierInfo *ii = macroNameTok.getIdentifierInfo()) {
-            maybeWarn(ii->getName(), macroNameTok.getLocation());
+            maybeWarn(static_cast<std::string>(ii->getName()), macroNameTok.getLocation());
         }
     }
 }
@@ -66,7 +66,7 @@ void IfndefDefineTypo::VisitIfdef(SourceLocation, const Token &)
 void IfndefDefineTypo::VisitIfndef(SourceLocation, const Token &macroNameTok)
 {
     if (IdentifierInfo *ii = macroNameTok.getIdentifierInfo())
-        m_lastIfndef = ii->getName();
+        m_lastIfndef = static_cast<std::string>(ii->getName());
 }
 
 void IfndefDefineTypo::VisitIf(SourceLocation, SourceRange, PPCallbacks::ConditionValueKind)

--- a/src/checks/manuallevel/qproperty-type-mismatch.cpp
+++ b/src/checks/manuallevel/qproperty-type-mismatch.cpp
@@ -237,7 +237,7 @@ void QPropertyTypeMismatch::VisitMacroExpands(const clang::Token &MacroNameTok, 
 
     CharSourceRange crange = Lexer::getAsCharRange(range, sm(), lo());
 
-    string text = Lexer::getSourceText(crange, sm(), lo());
+    string text = static_cast<std::string>(Lexer::getSourceText(crange, sm(), lo()));
     if (!text.empty() && text.back() == ')')
         text.pop_back();
 

--- a/src/checks/manuallevel/qrequiredresult-candidates.cpp
+++ b/src/checks/manuallevel/qrequiredresult-candidates.cpp
@@ -65,7 +65,7 @@ void QRequiredResultCandidates::VisitDecl(clang::Decl *decl)
 
 
     if (returnClass == classDecl) {
-        const std::string methodName = clazy::name(method);
+        const std::string methodName = static_cast<std::string>(clazy::name(method));
         if (methodName.empty()) // fixes assert
             return;
 

--- a/src/checks/manuallevel/qt-keywords.cpp
+++ b/src/checks/manuallevel/qt-keywords.cpp
@@ -59,12 +59,12 @@ void QtKeywords::VisitMacroExpands(const Token &macroNameTok, const SourceRange 
     }
 
     static const vector<StringRef> keywords = { "foreach", "signals", "slots", "emit" };
-    std::string name = ii->getName();
+    std::string name = static_cast<std::string>(ii->getName());
     if (!clazy::contains(keywords, name))
         return;
 
     // Make sure the macro is Qt's. It must be defined in Qt's headers, not 3rdparty
-    std::string qtheader = sm().getFilename(sm().getSpellingLoc(minfo->getDefinitionLoc()));
+    std::string qtheader = static_cast<std::string>(sm().getFilename(sm().getSpellingLoc(minfo->getDefinitionLoc())));
     if (!clazy::endsWith(qtheader, "qglobal.h") && !clazy::endsWith(qtheader, "qobjectdefs.h"))
         return;
 

--- a/src/checks/manuallevel/reserve-candidates.cpp
+++ b/src/checks/manuallevel/reserve-candidates.cpp
@@ -78,7 +78,8 @@ static bool isCandidateMethod(CXXMethodDecl *methodDecl)
     if (!classDecl)
         return false;
 
-    if (!clazy::equalsAny(clazy::name(methodDecl), { "append", "push_back", "push", "operator<<", "operator+=" }))
+    if (!clazy::equalsAny(static_cast<std::string>(clazy::name(methodDecl)),
+                 { "append", "push_back", "push", "operator<<", "operator+=" }))
         return false;
 
     if (!clazy::isAReserveClass(classDecl))


### PR DESCRIPTION
*1.* In LLVM 10 llvm::StringRef operator std::string() is marked as explicit. In this commit all implicit conversion from llvm::StringRef to std::string are changed by explicit.
*2.* Also included header file clang/Basic/FileManager.h in src/MiniDumper because without this header, class clang::FileEntry in incomplete class